### PR TITLE
bugfix-select-and-move-shape-when-nofil-only-stroke

### DIFF
--- a/shapes/shape.js
+++ b/shapes/shape.js
@@ -49,9 +49,9 @@ class Shape {
       ctx.fillStyle = `rgb(${red},${green},${blue})`;
       ctx.strokeStyle = `rgb(${red},${green},${blue})`;
       ctx.lineWidth = this.options.strokeWidth + dilation;
-      if (this.options.fill) {
-         ctx.fill();
-      }
+       //if (this.options.fill) {
+         ctx.fill();  //Rajesh Pillai: commented to always fill offcanvas to avoid select and drag where shape is not filled
+      //}
       if (this.options.stroke) {
          ctx.stroke();
       }


### PR DESCRIPTION
When a shape is drawn with stroke and no-fill, the selection tool doesn't work as expected. You have to select the border in order to move it.  Ideally selecting anywhere within the shape should enable us to move it.

This thing work when the shape is filled.

Just thought of fixing this as this was a small fix in shape.js.  Instead of checking for fill, always fill the offcanvas to enable
hit testing with shapes (I am not sure of any edge cases of it) but thought of trying and raise a pull request.

In case you think this is good feel free to merge.