### PR TITLE
reset properties panel on draw delete or deselect

### DIFF
--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -166,7 +166,6 @@ class PropertiesPanel {
 
    static updateDisplay(selectedShapes) {
       if (selectedShapes.length === 0) {
-         document.getElementById("properties").innerHTML = "";
          return;
       }
 

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -157,6 +157,13 @@ class PropertiesPanel {
       drawShapes(shapes);
    }
 
+   static reset() {
+      x.value = "";
+      y.value = "";
+      width.value = "";
+      height.value = "";
+   }
+
    static updateDisplay(selectedShapes) {
       if (selectedShapes.length === 0) {
          document.getElementById("properties").innerHTML = "";

--- a/script.js
+++ b/script.js
@@ -43,6 +43,8 @@ window.addEventListener("keydown", (e) => {
          shapes.findIndex((s) => s.selected),
          1
       );
+      // comment
+      PropertiesPanel.reset()
       drawShapes(shapes);
    }
 

--- a/toolEvents.js
+++ b/toolEvents.js
@@ -12,7 +12,10 @@ function downCallbackForSelect(e) {
    const id = (r << 16) | (g << 8) | b;
    const shape = shapes.find((s) => s.id == id);
 
-   shapes.forEach((s) => (s.selected = false));
+   if (e.ctrlKey === false) {
+      shapes.forEach((s) => (s.selected = false));
+   }
+
    drawShapes(shapes);
 
    if (shape) {
@@ -36,5 +39,68 @@ function downCallbackForSelect(e) {
       };
       myCanvas.addEventListener("pointermove", moveCallback);
       myCanvas.addEventListener("pointerup", upCallback);
+   } else {
+      selectShapesUnderRectangle(e)
    }
+}
+
+function selectShapesUnderRectangle(e) {
+   const startPosition = {x: e.offsetX, y: e.offsetY};
+
+   let rect = document.createElement("div")
+   rect.style.position = "fixed"
+   rect.style.backgroundColor = "transparent"
+   rect.style.border = "1px dotted"
+   const htmlBody = document.querySelector("body")
+   htmlBody.appendChild(rect)
+
+   let rectMinX, rectMinY, rectMaxX, rectMaxY = 0
+
+   const moveCallback = function (e) {
+      const mousePosition = {x: e.clientX, y: e.clientY};
+      rectMinX = Math.min(startPosition.x, mousePosition.x);
+      rectMinY = Math.min(startPosition.y, mousePosition.y);
+      const width = Math.abs(startPosition.x - mousePosition.x);
+      const height = Math.abs(startPosition.y - mousePosition.y);
+      rectMaxX = rectMinX + width
+      rectMaxY = rectMinY + height
+      const left = rectMinX;
+      const top = rectMinY;
+      rect.style.left = `${left}px`
+      rect.style.top = `${top}px`
+      rect.style.width = `${width}px`
+      rect.style.height = `${height}px`
+   };
+
+   const upCallback = function (e) {
+      myCanvas.removeEventListener("pointermove", moveCallback);
+      myCanvas.removeEventListener("pointerup", upCallback);
+      rect.removeEventListener("pointerup", upCallback);
+      rect.removeEventListener("pointermove", moveCallback)
+
+      shapes.forEach(shape => {
+         const points = shape.getPoints();
+         const minX = Math.min(...points.map((p) => p.x + shape.center.x));
+         const minY = Math.min(...points.map((p) => p.y + shape.center.y));
+         const maxX = Math.max(...points.map((p) => p.x + shape.center.x));
+         const maxY = Math.max(...points.map((p) => p.y + shape.center.y));
+
+         if (minX >= rectMinX && maxX <= rectMaxX && minY >= rectMinY && maxY <= rectMaxY) {
+            shape.selected = true
+         }
+
+      })
+
+      rect.remove()
+      PropertiesPanel.updateDisplay(shapes.filter((s) => s.selected));
+      drawShapes(shapes)
+      updateHistory(shapes);
+   };
+   
+   // adding eventlisteners to rect to allow rect redraw when
+   // pointer moves into it
+   myCanvas.addEventListener("pointermove", moveCallback);
+   myCanvas.addEventListener("pointerup", upCallback);
+   rect.addEventListener("pointerup", upCallback);
+   rect.addEventListener("pointermove", moveCallback)
 }

--- a/toolEvents.js
+++ b/toolEvents.js
@@ -1,4 +1,5 @@
 function downCallbackForSelect(e) {
+   PropertiesPanel.reset()
    const startPosition = new Vector(e.offsetX, e.offsetY);
 
    const [r, g, b, a] = hitTestingCtx.getImageData(


### PR DESCRIPTION
Noticed if i select a drawing, it properties shows on the propertiesPanel as expected, however on delete or deselecting the drawing, it still displays its properties. maybe we could reset the panel after deleting and on downCallbackForSelect