### PR TITLE
Adds simple utility to exchange and swap colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -126,6 +126,19 @@ function selectSelectTool() {
    selectTool("select");
 }
 
+function resetColors() {
+   fillColor.value = '#ffffff';
+   strokeColor.value = '#000000';
+}
+
+function swapColors() {
+   const fillStyle = fillColor.value;
+   const strokeStyle = strokeColor.value;
+
+   fillColor.value = strokeStyle;
+   strokeColor.value = fillStyle;
+}
+
 function getOptions() {
    return {
       fillColor: fillColor.value,

--- a/utils/shortcuts.js
+++ b/utils/shortcuts.js
@@ -4,6 +4,8 @@ const shortcuts = [
    { control: false, key: "v", action: selectSelectTool },
    { control: false, key: "o", action: selectOvalTool },
    { control: false, key: "t", action: selectTextTool },
+   { control: false, key: "d", action: resetColors },
+   { control: false, key: "x", action: swapColors },
    { control: true, key: "z", action: undo },
    { control: true, key: "y", action: redo },
    { control: true, key: "a", action: selectAll },


### PR DESCRIPTION
This commit adds color swap and exchange abilities similar to Photoshop.  

By pressing `d`, the colors switch to black for stroke and white for fill.
By pressing `x`, the stroke and fill colors get swapped.