### PR TITLE
fix: stop path autoflip after already flipped

### DIFF
--- a/shapes/myImage.js
+++ b/shapes/myImage.js
@@ -47,12 +47,25 @@ class MyImage extends Shape {
    }
 
    setWidth(width) {
-      this.size.width = width;
+      if (Gizmo.canFlip.x) {
+         Gizmo.canFlip.x = false
+         width = Math.abs(width) * Math.sign(this.size.width) * -1
+      } else {
+         width = Math.abs(width) * Math.sign(this.size.width);
+      }
+      this.size.width = width
    }
 
    setHeight(height) {
-      this.size.height = height;
+      if (Gizmo.canFlip.y) {
+         Gizmo.canFlip.y = false
+         height = Math.abs(height) * Math.sign(this.size.height) * -1
+      } else {
+         height = Math.abs(height) * Math.sign(this.size.height);
+      }
+      this.size.height = height
    }
+   
 
    draw(ctx, hitRegion = false) {
       const center = this.center ? this.center : { x: 0, y: 0 };

--- a/shapes/path.js
+++ b/shapes/path.js
@@ -43,8 +43,8 @@ class Path extends Shape {
       let flip = 1
 
       if (Gizmo.shouldTrackFlip) {
-         if (Gizmo.canFlip) {
-            Gizmo.canFlip = false
+         if (Gizmo.canFlip.x) {
+            Gizmo.canFlip.x = false
             flip = Math.sign(width) !== Math.sign(this.size.width) ? -1 : 1;
          }
       } else {
@@ -68,8 +68,8 @@ class Path extends Shape {
       let flip = 1
 
       if (Gizmo.shouldTrackFlip) {
-         if (Gizmo.canFlip) {
-            Gizmo.canFlip = false
+         if (Gizmo.canFlip.y) {
+            Gizmo.canFlip.y = false
             flip = Math.sign(height) !== Math.sign(this.size.height) ? -1 : 1;
          }
       } else {

--- a/shapes/path.js
+++ b/shapes/path.js
@@ -40,25 +40,45 @@ class Path extends Shape {
 
    setWidth(width) {
       const size = getSize(this.points);
-      const flip = Math.sign(width) != Math.sign(this.size.width) ? -1 : 1;
+      let flip = 1
+
+      if (Gizmo.shouldTrackFlip) {
+         if (Gizmo.canFlip) {
+            Gizmo.canFlip = false
+            flip = Math.sign(width) !== Math.sign(this.size.width) ? -1 : 1;
+         }
+      } else {
+         flip = Math.sign(width) !== Math.sign(this.size.width) ? -1 : 1;
+      }
+      
       const eps = 0.0001;
       if (size.width == 0) {
-         console.err("Size 0 problem!");
+         console.error("Size 0 problem!");
       }
       const _width = size.width == 0 ? eps : size.width;
       const ratio = (flip * Math.abs(width)) / _width;
       for (const point of this.points) {
-         point.x *= ratio;
+         point.x *= ratio
       }
       this.size.width = width;
    }
 
    setHeight(height) {
       const size = getSize(this.points);
-      const flip = Math.sign(height) != Math.sign(this.size.height) ? -1 : 1;
+      let flip = 1
+
+      if (Gizmo.shouldTrackFlip) {
+         if (Gizmo.canFlip) {
+            Gizmo.canFlip = false
+            flip = Math.sign(height) !== Math.sign(this.size.height) ? -1 : 1;
+         }
+      } else {
+         flip = Math.sign(height) !== Math.sign(this.size.height) ? -1 : 1;
+      }
+      
       const eps = 0.0001;
       if (size.height == 0) {
-         console.err("Size 0 problem!");
+         console.error("Size 0 problem!");
       }
       const _height = size.height == 0 ? eps : size.height;
       const ratio = (flip * Math.abs(height)) / _height;
@@ -67,6 +87,7 @@ class Path extends Shape {
       }
       this.size.height = height;
    }
+
 
    draw(ctx, hitRegion = false) {
       const center = this.center ? this.center : { x: 0, y: 0 };

--- a/transformBox/gizmo.js
+++ b/transformBox/gizmo.js
@@ -1,6 +1,6 @@
 class Gizmo {
 	static shouldTrackFlip = false
-	static canFlip = false
+	static canFlip = {x: false, y:false}
 	constructor(shape) {
 		this.shape = shape;
 
@@ -142,7 +142,7 @@ class Gizmo {
 
 		const upCallback = (e) => {
 			Gizmo.shouldTrackFlip = false
-			Gizmo.canFlip = false
+			Gizmo.canFlip = {x: false, y: false}
 			viewport.canvas.removeEventListener("pointermove", moveCallback);
 			viewport.canvas.removeEventListener("pointerup", upCallback);
 		};
@@ -151,8 +151,11 @@ class Gizmo {
 	}
 
 	static setCanFlip(prevRatioX, ratioX, prevRatioY, ratioY) {
-		if (Math.sign(prevRatioX) !== Math.sign(ratioX) || Math.sign(prevRatioY) !== Math.sign(ratioY)) {
-			Gizmo.canFlip = true
+		if (Math.sign(prevRatioX) !== Math.sign(ratioX)) {
+			Gizmo.canFlip.x = true
+		}
+		if (Math.sign(prevRatioY) !== Math.sign(ratioY)) {
+			Gizmo.canFlip.y = true
 		}
 	}
 


### PR DESCRIPTION
previously, after using Gizmo handles to manipulate Path or MyImage shapes, it autoflips to its original flip state after flipping.