### PR TITLE
Fix: createInputWithLabel previous behavior

### DIFF
--- a/utils/misc.js
+++ b/utils/misc.js
@@ -36,7 +36,7 @@ function createDOMElement(type, attributes, text) {
 function createInputWithLabel(labelText, attributes) {
 	const element = document.createElement("div");
 	element.appendChild(
-		createDOMElement("label", { for: attributes["id"] }, `${labelText}: `)
+		createDOMElement("label", { for: attributes["id"] || labelText.toLowerCase() }, `${labelText}: `)
 	);
 	element.appendChild(
 		createDOMElement("input", {


### PR DESCRIPTION
Fix previous implementation of `createInputWithLabel` function to support not passing an id