### PR TITLE
Feature/shape front back

### DIFF
--- a/display/viewport.js
+++ b/display/viewport.js
@@ -101,10 +101,10 @@ class Viewport extends EventTarget {
 		return this.shapes.filter((s) => s.selected);
 	}
 
-   selectShapes(shapes) {
-      this.shapes.forEach((s) => s.unselect(false));
-      shapes.forEach((s) => s.select(false));
-   }
+	selectShapes(shapes) {
+		this.shapes.forEach((s) => s.unselect(false));
+		shapes.forEach((s) => s.select(false));
+	}
 
 	getStageCanvas() {
 		return this.stageLayer.canvas;
@@ -189,5 +189,9 @@ class Viewport extends EventTarget {
 			this.#handleChanges(event);
 		});
 		this.addEventListener("gizmoChanged", () => this.drawShapes());
+	}
+
+	static getSelectedIndex() {
+		return viewport.shapes.findIndex((s) => s.selected);
 	}
 }

--- a/index.html
+++ b/index.html
@@ -27,11 +27,6 @@
 		<script src="shapes/rect.js"></script>
 		<script src="shapes/path.js"></script>
 		<script src="shapes/myImage.js"></script>
-
-		<script src="tools/documentTools.js"></script>
-		<script src="tools/historyTools.js"></script>
-		<script src="tools/editingTools.js"></script>
-
 		<script src="tools/selectTool.js"></script>
 		<script src="tools/shapes/shapeTool.js"></script>
 		<script src="tools/shapes/pathTool.js"></script>
@@ -41,6 +36,11 @@
 		<script src="tools/shapes/rectTool.js"></script>
 		<script src="tools/shapes/ovalTool.js"></script>
 		<script src="tools/canvasTools.js"></script>
+
+		<script src="tools/documentTools.js"></script>
+		<script src="tools/historyTools.js"></script>
+		<script src="tools/editingTools.js"></script>
+		<script src="tools/transformTools.js"></script>
 
 		<script src="panels/propertiesPanel.js"></script>
 		<script src="panels/toolsPanel.js"></script>

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -78,6 +78,52 @@ class PropertiesPanel {
 				id: "constrainDimensions",
 			})
 		);
+
+		transformSection.appendChild(
+			createDOMElement(
+				"button",
+				{
+					id: "sendBackBtn",
+					onclick: "TransformTools.sendBack()",
+					title: "Send to Back",
+				},
+				"Send to Back"
+			)
+		);
+		transformSection.appendChild(
+			createDOMElement(
+				"button",
+				{
+					id: "bringFrontBtn",
+					onclick: "TransformTools.bringFront()",
+					title: "Bring to Front",
+				},
+				"Bring to Front"
+			)
+		);
+		transformSection.appendChild(
+			createDOMElement(
+				"button",
+				{
+					id: "sendBackwardBtn",
+					onclick: "TransformTools.sendBackward()",
+					title: "Send Backward",
+				},
+				"Send Backward"
+			)
+		);
+		transformSection.appendChild(
+			createDOMElement(
+				"button",
+				{
+					id: "bringForwardBtn",
+					onclick: "TransformTools.bringForward()",
+					title: "Bring Forward",
+				},
+				"Bring Forward"
+			)
+		);
+
 		colorSection.appendChild(
 			createDOMElement("input", {
 				id: "fillColor",
@@ -137,7 +183,7 @@ class PropertiesPanel {
 				oninput: "PropertiesPanel.changeStrokeWidth(this.value, false)",
 				title: "Stroke Width",
 				type: "range",
-				value: "5",
+				value: "1",
 			})
 		);
 		textSection.appendChild(

--- a/tools/transformTools.js
+++ b/tools/transformTools.js
@@ -1,0 +1,59 @@
+class TransformTools {
+	/**
+	 * Send a shape to back by one level.
+	 */
+	static sendBack() {
+		const currentIndex = ShapeTools.getSelectedIndex();
+		const newIndex = currentIndex - 1;
+
+		if (newIndex < 0) {
+			throw new Error("Can't move the shape back!");
+		}
+
+		moveItem(shapes, currentIndex, newIndex);
+		HistoryTools.record();
+		viewport.drawShapes();
+	}
+
+	/**
+	 * Bring a shape to front by one level.
+	 */
+	static bringFront() {
+		const count = shapes.length;
+		const currentIndex = ShapeTools.getSelectedIndex();
+		const newIndex = currentIndex + 1;
+
+		if (newIndex >= count) {
+			throw new Error("Can't move the shape front!");
+		}
+
+		moveItem(shapes, currentIndex, newIndex);
+		HistoryTools.record();
+		viewport.drawShapes();
+	}
+
+	/**
+	 * Send a shape behind all shapes.
+	 */
+	static sendBackward() {
+		const currentIndex = ShapeTools.getSelectedIndex();
+		const newIndex = 0;
+
+		moveItem(shapes, currentIndex, newIndex);
+		HistoryTools.record();
+		viewport.drawShapes();
+	}
+
+	/**
+	 * Bring a shape in front of all shapes.
+	 */
+	static bringForward() {
+		const count = shapes.length;
+		const currentIndex = ShapeTools.getSelectedIndex();
+		const newIndex = count - 1;
+
+		moveItem(shapes, currentIndex, newIndex);
+		HistoryTools.record();
+		viewport.drawShapes();
+	}
+}

--- a/tools/transformTools.js
+++ b/tools/transformTools.js
@@ -3,15 +3,15 @@ class TransformTools {
 	 * Send a shape to back by one level.
 	 */
 	static sendBack() {
-		const currentIndex = ShapeTools.getSelectedIndex();
+		const currentIndex = Viewport.getSelectedIndex();
 		const newIndex = currentIndex - 1;
 
 		if (newIndex < 0) {
 			throw new Error("Can't move the shape back!");
 		}
 
-		moveItem(shapes, currentIndex, newIndex);
-		HistoryTools.record();
+		moveItem(viewport.shapes, currentIndex, newIndex);
+		HistoryTools.record(viewport.shapes);
 		viewport.drawShapes();
 	}
 
@@ -19,16 +19,16 @@ class TransformTools {
 	 * Bring a shape to front by one level.
 	 */
 	static bringFront() {
-		const count = shapes.length;
-		const currentIndex = ShapeTools.getSelectedIndex();
+		const count = viewport.shapes.length;
+		const currentIndex = Viewport.getSelectedIndex();
 		const newIndex = currentIndex + 1;
 
 		if (newIndex >= count) {
 			throw new Error("Can't move the shape front!");
 		}
 
-		moveItem(shapes, currentIndex, newIndex);
-		HistoryTools.record();
+		moveItem(viewport.shapes, currentIndex, newIndex);
+		HistoryTools.record(viewport.shapes);
 		viewport.drawShapes();
 	}
 
@@ -36,11 +36,15 @@ class TransformTools {
 	 * Send a shape behind all shapes.
 	 */
 	static sendBackward() {
-		const currentIndex = ShapeTools.getSelectedIndex();
+		const currentIndex = Viewport.getSelectedIndex();
 		const newIndex = 0;
 
-		moveItem(shapes, currentIndex, newIndex);
-		HistoryTools.record();
+		if (currentIndex === newIndex) {
+			throw new Error("Can't move the shape back!");
+		}
+
+		moveItem(viewport.shapes, currentIndex, newIndex);
+		HistoryTools.record(viewport.shapes);
 		viewport.drawShapes();
 	}
 
@@ -48,12 +52,16 @@ class TransformTools {
 	 * Bring a shape in front of all shapes.
 	 */
 	static bringForward() {
-		const count = shapes.length;
-		const currentIndex = ShapeTools.getSelectedIndex();
+		const count = viewport.shapes.length;
+		const currentIndex = Viewport.getSelectedIndex();
 		const newIndex = count - 1;
 
-		moveItem(shapes, currentIndex, newIndex);
-		HistoryTools.record();
+		if (currentIndex === newIndex) {
+			throw new Error("Can't move the shape front!");
+		}
+
+		moveItem(viewport.shapes, currentIndex, newIndex);
+		HistoryTools.record(viewport.shapes);
 		viewport.drawShapes();
 	}
 }

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -56,3 +56,24 @@ function getSignedAngleBetweenVectors(A, B) {
 function formatAngle(angle) {
 	return (angle * 180) / Math.PI;
 }
+
+/**
+ * Move an item in the list to a new position.
+ * @param {Array} list - List of items to update
+ * @param {number} fromIndex - Current index of the item in the list
+ * @param {number} toIndex - Index of the item to move to in the list
+ */
+function moveItem(list, fromIndex, toIndex) {
+	if (
+		fromIndex < 0 ||
+		fromIndex >= list.length ||
+		toIndex < 0 ||
+		toIndex >= list.length
+	) {
+		throw new Error("Index out of bounds!");
+	}
+
+	const [item] = list.splice(fromIndex, 1);
+
+	list.splice(toIndex, 0, item);
+}


### PR DESCRIPTION
This PR adds an ability to handle shape ordering. i.e. sending shapes to back or front.

The ordering functionality has 4 options.
1. Send Back: Sends the selected shape back by one level.
2. Bring Front: Brings the selected shape to top by one level.
3. Send Backward:  Sends the selected shape to back of all shapes.
4. Bring Forward: Brings the selected shape to the top of all shapes.

Please note, this only works for one of the selected shapes.