### PR TITLE
fix: PropertiesPanel.setWidth and Height not allowing negative values

### DIFF
--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -61,7 +61,7 @@ class PropertiesPanel {
 		transformSection.appendChild(
 			createInputWithLabel("Width", {
 				type: "number",
-				// onchange: "PropertiesPanel.changeWidth(this.value)",
+				onchange: "PropertiesPanel.changeWidth(this.value)",
 				oninput: "PropertiesPanel.changeWidth(this.value, false)",
 				id: "widthInput",
 			})

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -61,7 +61,7 @@ class PropertiesPanel {
 		transformSection.appendChild(
 			createInputWithLabel("Width", {
 				type: "number",
-				onchange: "PropertiesPanel.changeWidth(this.value)",
+				// onchange: "PropertiesPanel.changeWidth(this.value)",
 				oninput: "PropertiesPanel.changeWidth(this.value, false)",
 				id: "widthInput",
 			})
@@ -296,13 +296,13 @@ class PropertiesPanel {
 	}
 
 	static changeWidth(value, save = true) {
-		let newWidth = Math.max(Number(value), 1);
+		let newWidth = value;
 		let newHeight = 0;
 
 		viewport.getSelectedShapes().forEach((s) => {
 			const currentWidth = s.size.width;
 			if (value == 0) {
-				newWidth *= Math.sign(currentWidth) * -1
+				newWidth = Math.sign(currentWidth) * -1
 			}
 			const currentHeight = s.size.height;
 			newHeight = currentHeight;
@@ -321,14 +321,14 @@ class PropertiesPanel {
 	}
 
 	static changeHeight(value, save = true) {
-		let newHeight = Math.max(Number(value), 1);
+		let newHeight = value;
 		let newWidth = 0;
 
 		viewport.getSelectedShapes().forEach((s) => {
 			const currentWidth = s.size.width;
 			const currentHeight = s.size.height;
 			if (value == 0) {
-				newHeight *= Math.sign(currentHeight) * -1
+				newHeight = Math.sign(currentHeight) * -1
 			}
 			newWidth = currentWidth;
 			if (constrainDimensions.checked) {

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -452,17 +452,17 @@ class PropertiesPanel {
 		let newProperties = PropertiesPanel.getNewProperties(selectedShapes)
 
 		for (let key in newProperties) {
-			let panelProperty = newProperties[key]
-			if (Number(panelProperty.value)) {
-				panelProperty.value = Math.round(panelProperty.value)
+			let newProperty = newProperties[key]
+			if (Number(newProperty.value)) {
+				newProperty.value = Math.round(newProperty.value)
 			}
 
 			if (key === "fill" || key === "stroke") {
-				panelFields[key].checked = panelProperty.value || false
+				panelFields[key].checked = newProperty.value || false
 			} else {
-				panelFields[key].value = panelProperty.value === null ? "" : panelProperty.value
+				panelFields[key].value = newProperty.value === null ? "" : newProperty.value
 			}
-			panelFields[key].placeholder = key === "text" ? "Enter Text" : panelProperty.value || placeholderText
+			panelFields[key].placeholder = key === "text" ? "Enter Text" : newProperty.value || placeholderText
 		}
 	}
 

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -296,11 +296,14 @@ class PropertiesPanel {
 	}
 
 	static changeWidth(value, save = true) {
-		const newWidth = Math.max(Number(value), 1);
+		let newWidth = Math.max(Number(value), 1);
 		let newHeight = 0;
 
 		viewport.getSelectedShapes().forEach((s) => {
 			const currentWidth = s.size.width;
+			if (value == 0) {
+				newWidth *= Math.sign(currentWidth) * -1
+			}
 			const currentHeight = s.size.height;
 			newHeight = currentHeight;
 			if (constrainDimensions.checked) {
@@ -318,12 +321,15 @@ class PropertiesPanel {
 	}
 
 	static changeHeight(value, save = true) {
-		const newHeight = Math.max(Number(value), 1);
+		let newHeight = Math.max(Number(value), 1);
 		let newWidth = 0;
 
 		viewport.getSelectedShapes().forEach((s) => {
 			const currentWidth = s.size.width;
 			const currentHeight = s.size.height;
+			if (value == 0) {
+				newHeight *= Math.sign(currentHeight) * -1
+			}
 			newWidth = currentWidth;
 			if (constrainDimensions.checked) {
 				const aspectRatio = currentWidth / currentHeight;

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -204,7 +204,8 @@ class PropertiesPanel {
 				oninput: "PropertiesPanel.changeText(this.value)",
 				title: "Text",
 				type: "text",
-				value: "TEST",
+				value: "",
+				placeholder: "Enter Text"
 			})
 		);
 
@@ -441,101 +442,68 @@ class PropertiesPanel {
 			return;
 		}
 
+		const panelFields = {
+			xInput, yInput, widthInput, heightInput, fillColor, fill, 
+			strokeColor, stroke, strokeWidth, text, rotationInput
+		}
+
+		const placeholderText = "Multiple Values";
+
+		let newProperties = PropertiesPanel.getNewProperties(selectedShapes)
+
+		for (let key in newProperties) {
+			let panelProperty = newProperties[key]
+			if (Number(panelProperty.value)) {
+				panelProperty.value = Math.round(panelProperty.value)
+			}
+
+			if (key === "fill" || key === "stroke") {
+				panelFields[key].checked = panelProperty.value || false
+			} else {
+				panelFields[key].value = panelProperty.value === null ? "" : panelProperty.value
+			}
+			panelFields[key].placeholder = key === "text" ? "Enter Text" : panelProperty.value || placeholderText
+		}
+	}
+
+	static getNewProperties(selectedShapes) {
+		let getX = (shape) => shape.center.x - STAGE_PROPERTIES.left
+		let getY = (shape) => shape.center.y - STAGE_PROPERTIES.top
+		let getWidth = (shape) => shape.size.width
+		let getHeight = (shape) => shape.size.height
+		let getFillColor = (shape) => shape.options.fillColor
+		let getFill = (shape) => shape.options.fill
+		let getStrokeColor = (shape) => shape.options.strokeColor
+		let getStroke = (shape) => shape.options.stroke
+		let getStrokeWidth = (shape) => shape.options.strokeWidth
+		let getText = (shape) => shape.text || null
+		let getRotation = (shape) => shape.rotation
+
 		let newProperties = null;
 		for (const shape of selectedShapes) {
 			if (newProperties === null) {
 				newProperties = {
-					x: shape.center.x - STAGE_PROPERTIES.left,
-					y: shape.center.y - STAGE_PROPERTIES.top,
-					width: shape.size.width,
-					height: shape.size.height,
-					fillColor: shape.options.fillColor,
-					fill: shape.options.fill,
-					strokeColor: shape.options.strokeColor,
-					stroke: shape.options.stroke,
-					strokeWidth: shape.options.strokeWidth,
-					text: shape.text,
-					rotationAngle: shape.rotation,
+					xInput: { value: getX(shape), extractor: getX },
+					yInput: { value: getY(shape), extractor: getY },
+					widthInput: { value: getWidth(shape), extractor: getWidth },
+					heightInput: { value: getHeight(shape), extractor: getHeight },
+					fillColor: { value: getFillColor(shape), extractor: getFillColor },
+					fill: { value: getFill(shape), extractor: getFill },
+					strokeColor: { value: getStrokeColor(shape), extractor: getStrokeColor },
+					stroke: { value: getStroke(shape), extractor: getStroke },
+					strokeWidth: { value: getStrokeWidth(shape), extractor: getStrokeWidth },
+					text: { value: getText(shape), extractor: getText },
+					rotationInput: { value: getRotation(shape), extractor: getRotation }
 				};
 			} else {
-				if (newProperties.x !== shape.center.x - STAGE_PROPERTIES.left) {
-					newProperties.x = null;
-				}
-				if (newProperties.y !== shape.center.y - STAGE_PROPERTIES.top) {
-					newProperties.y = null;
-				}
-				if (newProperties.width !== shape.size.width) {
-					newProperties.width = null;
-				}
-				if (newProperties.height !== shape.size.height) {
-					newProperties.height = null;
-				}
-				if (newProperties.fillColor !== shape.options.fillColor) {
-					newProperties.fillColor = null;
-				}
-				if (newProperties.fill !== shape.options.fill) {
-					newProperties.fill = null;
-				}
-				if (newProperties.strokeColor !== shape.options.strokeColor) {
-					newProperties.strokeColor = null;
-				}
-				if (newProperties.stroke !== shape.options.stroke) {
-					newProperties.stroke = null;
-				}
-				if (newProperties.strokeWidth !== shape.options.strokeWidth) {
-					newProperties.strokeWidth = null;
-				}
-				if (newProperties.text !== shape.text) {
-					newProperties.text = null;
-				}
-				if (newProperties.rotationAngle !== shape.rotation) {
-					newProperties.rotationAngle = null;
-				}
+				for (let key in newProperties) {
+					let newPanelProperty = newProperties[key]
+					if (newPanelProperty.value !== newPanelProperty.extractor(shape)) {
+						newPanelProperty.value = null
+					}
+				}		
 			}
 		}
-		if (newProperties === null) {
-			return;
-		} else {
-			xInput.value = newProperties.x ? Math.round(newProperties.x) : "";
-			yInput.value = newProperties.y ? Math.round(newProperties.y) : "";
-			widthInput.value = newProperties.width
-				? Math.round(newProperties.width)
-				: "";
-			heightInput.value = newProperties.height
-				? Math.round(newProperties.height)
-				: "";
-			fillColor.value = newProperties.fillColor
-				? newProperties.fillColor
-				: "";
-			fill.checked = newProperties.fill ? newProperties.fill : false;
-			strokeColor.value = newProperties.strokeColor
-				? newProperties.strokeColor
-				: "";
-			stroke.checked = newProperties.stroke ? newProperties.stroke : false;
-			strokeWidth.value = newProperties.strokeWidth
-				? newProperties.strokeWidth
-				: "";
-			text.value = newProperties.text ? newProperties.text : "";
-			rotationInput.value = formatAngle(newProperties.rotationAngle) ?? "";
-
-			const placeholderText = "Multiple Values";
-			xInput.placeholder = newProperties.x ? "" : placeholderText;
-			yInput.placeholder = newProperties.y ? "" : placeholderText;
-			widthInput.placeholder = newProperties.width ? "" : placeholderText;
-			heightInput.placeholder = newProperties.height ? "" : placeholderText;
-			fillColor.placeholder = newProperties.fillColor ? "" : placeholderText;
-			fill.placeholder = newProperties.fill ? "" : placeholderText;
-			strokeColor.placeholder = newProperties.strokeColor
-				? ""
-				: placeholderText;
-			stroke.placeholder = newProperties.stroke ? "" : placeholderText;
-			strokeWidth.placeholder = newProperties.strokeWidth
-				? ""
-				: placeholderText;
-			text.placeholder = newProperties.text ? "" : placeholderText;
-			rotationInput.placeholder = newProperties.rotationAngle
-				? ""
-				: placeholderText;
-		}
+		return newProperties
 	}
 }

--- a/shapes/myImage.js
+++ b/shapes/myImage.js
@@ -48,22 +48,10 @@ class MyImage extends Shape {
 	}
 
 	_setWidth(width) {
-		if (Gizmo.canFlip.x) {
-			Gizmo.canFlip.x = false;
-			width = Math.abs(width) * Math.sign(this.size.width) * -1;
-		} else {
-			width = Math.abs(width) * Math.sign(this.size.width);
-		}
 		this.size.width = width;
 	}
 
 	_setHeight(height) {
-		if (Gizmo.canFlip.y) {
-			Gizmo.canFlip.y = false;
-			height = Math.abs(height) * Math.sign(this.size.height) * -1;
-		} else {
-			height = Math.abs(height) * Math.sign(this.size.height);
-		}
 		this.size.height = height;
 	}
 

--- a/shapes/path.js
+++ b/shapes/path.js
@@ -50,22 +50,15 @@ class Path extends Shape {
 		const box = BoundingBox.fromPoints(this.points);
 		let flip = 1;
 
-		if (Gizmo.shouldTrackFlip) {
-			if (Gizmo.canFlip.x) {
-				Gizmo.canFlip.x = false;
-				flip = Math.sign(newWidth) !== Math.sign(this.size.width) ? -1 : 1;
-			}
-		} else {
-			flip = Math.sign(newWidth) !== Math.sign(this.size.width) ? -1 : 1;
-		}
-
+		flip = Math.sign(newWidth) !== Math.sign(this.size.width) ? -1 : 1;
 		const eps = 0.0001;
 		if (box.width == 0) {
 			console.error("Size 0 problem!");
 		}
-		const width = box.width == 0 ? eps : box.width;
+		let width = box.width == 0 ? eps : box.width;
+
 		const ratio = (flip * Math.abs(newWidth)) / width;
-		console.log(newWidth, "<---")
+		
 		for (const point of this.points) {
 			point.x *= ratio;
 		}
@@ -76,15 +69,7 @@ class Path extends Shape {
 		const box = BoundingBox.fromPoints(this.points);
 		let flip = 1;
 
-		if (Gizmo.shouldTrackFlip) {
-			if (Gizmo.canFlip.y) {
-				Gizmo.canFlip.y = false;
-				flip =
-					Math.sign(newHeight) !== Math.sign(this.size.height) ? -1 : 1;
-			}
-		} else {
-			flip = Math.sign(newHeight) !== Math.sign(this.size.height) ? -1 : 1;
-		}
+		flip = Math.sign(newHeight) !== Math.sign(this.size.height) ? -1 : 1;
 
 		const eps = 0.0001;
 		if (box.height == 0) {

--- a/shapes/path.js
+++ b/shapes/path.js
@@ -65,6 +65,7 @@ class Path extends Shape {
 		}
 		const width = box.width == 0 ? eps : box.width;
 		const ratio = (flip * Math.abs(newWidth)) / width;
+		console.log(newWidth, "<---")
 		for (const point of this.points) {
 			point.x *= ratio;
 		}

--- a/tools/shapes/cornerGeneratedShapeTool.js
+++ b/tools/shapes/cornerGeneratedShapeTool.js
@@ -34,7 +34,7 @@ class CornerGeneratedShapeTool extends ShapeTool {
 			.removeEventListener("pointermove", moveCallback);
 		viewport.getStageCanvas().removeEventListener("pointerup", upCallback);
 
-		if (shape.size.width > 0 && shape.size.height > 0) {
+		if (shape?.size.width > 0 && shape?.size.height > 0) {
 			viewport.addShapes(shape);
 		}
 	}


### PR DESCRIPTION
- we can now set width and height to negative values from properties Panel
- refactored the ugly Gizmo.canflip style of preventing shape flip
- refactored PanelProperties.updateDisplay
- refactored selectTools.selectShapesUnderRectangle to use overlayLayout to draw rectangle as opposed using div and html body