### PR TITLE
History by layer

### DIFF
--- a/display/cursor.js
+++ b/display/cursor.js
@@ -29,6 +29,9 @@ class Cursor {
     }
 
     static handleKeyPress(e) {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+            return;
+        }
         let textShape = Cursor.currentText;
         let lines = textShape.parseText();
         let currentIndex = Cursor.currentIndex;
@@ -118,6 +121,11 @@ class Cursor {
     
             default:
                 let keyPressedValue = e.key;
+                if (keyPressedValue.length !== 1) {
+                    // speacial keys that has not been handled
+                    // e.g 'number lock' key
+                    return
+                }
                 line = line.slice(0, currentIndex + 1) + keyPressedValue + line.slice(currentIndex + 1)
                 Cursor.currentIndex++
                 lines[Cursor.currentLineIndex] = line

--- a/display/layer.js
+++ b/display/layer.js
@@ -77,6 +77,7 @@ class Layer {
 
 	serialize() {
 		return {
+			id: this.id,
 			type: this.type,
 			stageProperties: this.stageProperties,
 			shapes: this.shapes.map((s) => s.serialize()),

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -348,6 +348,7 @@ class PropertiesPanel {
 			};
 			if (viewport.selectedLayer == viewport.layers[i - 1]) {
 				props.checked = true;
+				props.labelClass = "highlight-bg"
 			}
 			PropertiesPanel.layersSection.appendChild(
 				createInputWithLabel("layer " + i, props)
@@ -714,7 +715,6 @@ class PropertiesPanel {
 		let getStrokeColor = (shape) => shape.options.strokeColor;
 		let getStroke = (shape) => shape.options.stroke;
 		let getStrokeWidth = (shape) => shape.options.strokeWidth;
-		let getText = (shape) => shape.text || null;
 		let getRotation = (shape) => shape.rotation;
 		let getFontSize = (shape) =>
 			shape.text !== undefined ? shape.getFontSize() : "";

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -264,7 +264,8 @@ class PropertiesPanel {
 					id: "textAlign" + alignment,
 					name: "textAlign",
 					class: "radio",
-					onchange: `PropertiesPanel.changeTextAlignment('${alignment}', false)`,
+					title: "align " + alignment.toLowerCase(),
+					onchange: `PropertiesPanel.changeTextAlignment('${alignment}', false)`
 				})
 			);
 		}
@@ -272,7 +273,7 @@ class PropertiesPanel {
 		PropertiesPanel.reset();
 		PropertiesPanel.resetColors();
 
-		PropertiesPanel.changeTextAlignment("Left", false);
+		PropertiesPanel.changeTextAlignment("Center", false);
 		LayerTools.selectLayer(0);
 
 		viewport.addEventListener(
@@ -606,6 +607,10 @@ class PropertiesPanel {
 		document.getElementById(`textAlignCenter`).checked = true;
 
 		PropertiesPanel.filtersSection.style.display = "none";
+		PropertiesPanel.textSection.querySelectorAll('label')
+		.forEach( label => {
+			label.style.backgroundColor = "transparent"
+		})
 		PropertiesPanel.textSection.style.display = "none";
 		PropertiesPanel.filtersHeader.style.display = "none";
 		PropertiesPanel.textHeader.style.display = "none";
@@ -682,7 +687,12 @@ class PropertiesPanel {
 					document.getElementById(`textAlignCenter`).checked = true;
 					let value = newProperty.value;
 					if (value) {
-						document.getElementById(`textAlign${value}`).checked = true;
+						const radio = document.getElementById(`textAlign${value}`)
+						radio.checked = true;
+						const label = PropertiesPanel.textSection.querySelector(
+							`label[for="${radio.id}"]`
+						);
+						label.style.backgroundColor = "var(--highlight-color)";
 					}
 					break;
 				default:

--- a/style.css
+++ b/style.css
@@ -325,3 +325,7 @@ input[type="checkbox"]:checked::before {
 	font-size: 22px;
 	position: absolute;
 }
+
+.highlight-bg {
+	background-color: var(--highlight-color);
+}

--- a/tools/historyTools.js
+++ b/tools/historyTools.js
@@ -1,12 +1,16 @@
 class HistoryTools {
-	static redoStack = [];
-	static undoStack = [];
+
+	static _stacksByLayer = {}
 
 	static redo() {
-		if (HistoryTools.redoStack.length > 0) {
-			const data = HistoryTools.redoStack.pop();
-         viewport.setLayers(data, false);
-			HistoryTools.undoStack.push(data);
+		let selectedLayerId = viewport.selectedLayer.id
+		let redoStack = HistoryTools._getRedoStackByLayerId(selectedLayerId)
+		let undoStack = HistoryTools._getUndoStackByLayerId(selectedLayerId)
+		if (redoStack.length > 0) {
+			const data = redoStack.pop();
+			viewport.selectedLayer = Layer.load(data, viewport.canvasWidth, viewport.canvasHeight)
+			viewport.swapLayerById(selectedLayerId, viewport.selectedLayer)
+			undoStack.push(data);
 		}
 		viewport.dispatchEvent(
 			new CustomEvent("history", { detail: { layers: viewport.layers } })
@@ -14,32 +18,61 @@ class HistoryTools {
 	}
 
 	static undo() {
-		if (!HistoryTools.undoStack.length) return; // prevent pushing undefined into redoStack
-		HistoryTools.redoStack.push(HistoryTools.undoStack.pop());
-		if (HistoryTools.undoStack.length > 0) {
-         const newLayers = HistoryTools.undoStack[HistoryTools.undoStack.length - 1];
-			viewport.setLayers(newLayers, false);
+		let selectedLayerId = viewport.selectedLayer.id
+		let redoStack = HistoryTools._getRedoStackByLayerId(selectedLayerId)
+		let undoStack = HistoryTools._getUndoStackByLayerId(selectedLayerId)
+		if (!undoStack.length) return; // prevent pushing undefined into redoStack
+		redoStack.push(undoStack.pop());
+		if (undoStack.length > 0) {
+         	const activeLayer = undoStack[undoStack.length - 1];
+			viewport.selectedLayer = Layer.load(activeLayer, viewport.canvasWidth, viewport.canvasHeight)
+			viewport.swapLayerById(selectedLayerId, viewport.selectedLayer)
 		} else {
-			viewport.setLayers([new Layer(
-            viewport.canvasWidth,
-            viewport.canvasHeight,
-            viewport.stageProperties,
-            Layer.TYPES.NORMAL
-         )], false);
+			viewport.selectedLayer = new Layer(
+				viewport.canvasWidth,
+				viewport.canvasHeight,
+				viewport.stageProperties,
+				Layer.TYPES.NORMAL
+        	)
+			viewport.swapLayerById(selectedLayerId, viewport.selectedLayer);
 		}
 		viewport.dispatchEvent(
 			new CustomEvent("history", { detail: { layers: viewport.layers } })
 		);
 	}
 
-	static record(layers) {
-		const newState = layers.map((l) => l.serialize());
-		if (HistoryTools.undoStack.length > 0) {
-			const lastItem =
-				HistoryTools.undoStack[HistoryTools.undoStack.length - 1];
-			if (JSON.stringify(lastItem) === JSON.stringify(newState)) return;
+	static record() {
+		let selectedLayerId = viewport.selectedLayer.id
+		let redoStack = HistoryTools._getRedoStackByLayerId(selectedLayerId)
+		let undoStack = HistoryTools._getUndoStackByLayerId(selectedLayerId)
+		const currentState = viewport.selectedLayer.serialize()
+		if (undoStack.length > 0) {
+			const lastItem = undoStack[undoStack.length - 1];
+			if (JSON.stringify(lastItem) === JSON.stringify(currentState)) return;
 		}
-		HistoryTools.undoStack.push(newState);
-		HistoryTools.redoStack.length = 0;
+		undoStack.push(currentState);
+		redoStack.length = 0;
+	}
+
+	static _getUndoStackByLayerId(layerId) {
+		if (HistoryTools._stacksByLayer[layerId]?.undoStack) {
+			return HistoryTools._stacksByLayer[layerId].undoStack
+		}
+		if (!HistoryTools._stacksByLayer[layerId]) {
+			HistoryTools._stacksByLayer[layerId] = {}
+		}
+		HistoryTools._stacksByLayer[layerId].undoStack = []
+		return HistoryTools._stacksByLayer[layerId].undoStack
+	}
+
+	static _getRedoStackByLayerId(layerId) {
+		if (HistoryTools._stacksByLayer[layerId]?.redoStack) {
+			return HistoryTools._stacksByLayer[layerId].redoStack
+		}
+		if (!HistoryTools._stacksByLayer[layerId]) {
+			HistoryTools._stacksByLayer[layerId] = {}
+		}
+		HistoryTools._stacksByLayer[layerId].redoStack = []
+		return HistoryTools._stacksByLayer[layerId].redoStack
 	}
 }

--- a/tools/layerTools.js
+++ b/tools/layerTools.js
@@ -6,7 +6,7 @@ class LayerTools {
 
 	static removeLayer(index) {
 		viewport.removeLayerByIndex(index);
-		LayerTools.selectLayer(0);
+		LayerTools.selectLayer(Math.max(0, index - 1));
 	}
 
 	static selectLayer(index) {

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -62,13 +62,13 @@ function createRadioWithImage(labelText, attributes) {
 	const image = new Image();
 	image.src = `drawings/icons/${labelText.toLowerCase()}.png`;
 	image.classList.add("icon");
+	image.title = attributes.title || labelText
 	label.appendChild(image);
 
 	element.appendChild(label);
 	element.appendChild(
 		createDOMElement("input", {
 			id: labelText.toLowerCase(),
-			title: labelText,
 			...attributes,
 		})
 	);


### PR DESCRIPTION
This update limits history changes to affect only shapes, so undo/redo does not affect layers. 
Initially undo/redo could delete and re-add layers in addition to shapes.

PROS:
- We can now work on different layers, use undo/redo functionalities that affect only the currently selected layer, so other layers remain unaffected.

CONS:
- Initially we could delete a layer and still have it back by undoing that action. with this current change, deleting a layer means it can never be recorvered, unless you have a json backup somewhere.