### PR TITLE
Create shortcutmanager class and move shortcuts in the tools themselves

### DIFF
--- a/display/cursor.js
+++ b/display/cursor.js
@@ -4,28 +4,21 @@ class Cursor {
     static currentIndex = 0
     static currentLineIndex = 0
     static currentIntervalId = null
+    static isEditing = false
 
     static enterEditMode(textShape, index, lineIndex) {
         Cursor.currentText = textShape
         Cursor.currentIndex = index
         Cursor.currentLineIndex = lineIndex
 
-        Cursor.disableKeyPressListeners()
         Cursor.addEventListeners()
+        Cursor.isEditing = true;
 
         Cursor.startCursorBlink()
     }
 
     static addEventListeners() {
         document.addEventListener("keydown", Cursor.handleKeyPress)
-    }
-
-    static disableKeyPressListeners() {
-        document.removeEventListener("keydown", handleShortCutKeysPress);
-    }
-
-    static restoreKeyPressListeners() {
-        document.addEventListener("keydown", handleShortCutKeysPress);
     }
 
     static handleKeyPress(e) {
@@ -41,6 +34,8 @@ class Cursor {
             case 'Control':
             case 'Shift':
             case 'Alt':
+            case 'Meta':
+            case 'Tab':
                 return
             case 'Home':
                 Cursor.currentIndex = -1
@@ -173,7 +168,7 @@ class Cursor {
         Cursor.currentText = null
         Cursor.currentIndex = 0
         Cursor.currentLineIndex = 0
-        Cursor.restoreKeyPressListeners()
+        Cursor.isEditing = false
         document.removeEventListener("keydown", Cursor.handleKeyPress)
         viewport.drawShapes()
     }

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 
 		<script src="utils/vector.js"></script>
 		<script src="utils/boundingBox.js"></script>
+		<script src="utils/shortcuts.js"></script>
 
 		<script src="display/layer.js"></script>
 		<script src="display/viewport.js"></script>
@@ -31,6 +32,7 @@
 		<script src="shapes/path.js"></script>
 		<script src="shapes/line.js"></script>
 		<script src="shapes/myImage.js"></script>
+		<script src="tools/genericTool.js"></script>
 		<script src="tools/selectTool.js"></script>
 		<script src="tools/shapes/shapeTool.js"></script>
 		<script src="tools/shapes/pathGeneratedShapeTool.js"></script>
@@ -55,7 +57,7 @@
 		<script src="contributors.js"></script>
 		<script src="utils/misc.js"></script>
 		<script src="main.js"></script>
-		<script src="utils/shortcuts.js"></script>
+		
 		<script src="transformBox/gizmo.js"></script>
 		<script src="transformBox/handle.js"></script>
 	</body>

--- a/panels/propertiesPanel.js
+++ b/panels/propertiesPanel.js
@@ -199,7 +199,7 @@ class PropertiesPanel {
 		colorSection.appendChild(
 			createButtonWithIcon({
 				id: "resetBtn",
-				title: "Reset",
+				title: "Reset (D)",
 				class: "tool-button",
 				onclick: "PropertiesPanel.resetColors()",
 				iconName: "reset_colors",
@@ -226,7 +226,7 @@ class PropertiesPanel {
 		colorSection.appendChild(
 			createButtonWithIcon({
 				id: "swapBtn",
-				title: "Swap",
+				title: "Swap (X)",
 				class: "tool-button",
 				onclick: "PropertiesPanel.swapColors()",
 				iconName: "swap_colors",
@@ -259,7 +259,7 @@ class PropertiesPanel {
 		textSection.appendChild(alignmentDiv);
 		for (let alignment of ["Left", "Center", "Right"]) {
 			alignmentDiv.appendChild(
-				createRadioWithImage("text_" + alignment.toLowerCase(), {
+				createRadioWithImage("text_" + alignment.toLowerCase(), alignment, {
 					type: "radio",
 					id: "textAlign" + alignment,
 					name: "textAlign",
@@ -294,6 +294,13 @@ class PropertiesPanel {
 		viewport.addEventListener("layersChanged", (e) => {
 			this.populateLayers(e.detail.count);
 		});
+
+		this.registerShortcuts();
+	}
+
+	registerShortcuts() {
+		shortcutManager.addShortcut(new Shortcut({ control: false, key: "d", action: PropertiesPanel.resetColors }));
+		shortcutManager.addShortcut(new Shortcut({ control: false, key: "x", action: PropertiesPanel.swapColors }));
 	}
 
 	static showFilters(filters) {

--- a/panels/toolsPanel.js
+++ b/panels/toolsPanel.js
@@ -3,7 +3,7 @@ class ToolsPanel {
 		this.holderDiv = holderDiv;
 
 		this.#addDocumentTools(holderDiv);
-      holderDiv.appendChild(createDOMElement("hr"));
+      	holderDiv.appendChild(createDOMElement("hr"));
 
 		this.#addEditingTools(holderDiv);
 		holderDiv.appendChild(createDOMElement("hr"));
@@ -19,92 +19,70 @@ class ToolsPanel {
 	}
 
 	#addDocumentTools(holderDiv) {
-		holderDiv.appendChild(
-			createButtonWithIcon({
-				id: "saveBtn",
-				title: "Save",
-				class: "tool-button",
-				onclick: "DocumentTools.save()",
-				iconName: "save",
-			})
-		);
-		holderDiv.appendChild(
-			createButtonWithIcon({
-				id: "exportBtn",
-				title: "Export",
-				class: "tool-button",
-				onclick: "DocumentTools.do_export()",
-				iconName: "export",
-			})
-		);
-		holderDiv.appendChild(
-			createButtonWithIcon({
-				id: "loadBtn",
-				title: "Load",
-				class: "tool-button",
-				onclick: "DocumentTools.load()",
-				iconName: "load",
-			})
-		);
+		for (let tool of DocumentTools.tools) {
+			if (!tool.showButton) continue;
+
+			const shortcut = tool.shortcut;
+			holderDiv.appendChild(
+				createButtonWithIcon({
+					id: tool.name + "Btn",
+					title: (shortcut ? `${tool.name} (${shortcut.toString()})` : tool.name),
+					class: "tool-button",
+					onclick: tool.func,
+					iconName: tool.icon ?? tool.name.toLowerCase(),
+				})
+			);
+		}
+
+		DocumentTools.registerShortcuts();
 	}
 
 	#addEditingTools(holderDiv) {
-		holderDiv.appendChild(
-         createButtonWithIcon({
-				id: "duplicateBtn",
-				title: "Duplicate",
-				class: "tool-button",
-				onclick: "DocumentTools.duplicate()",
-				iconName: "copy",
-			})
-		);
-		holderDiv.appendChild(
-         createButtonWithIcon({
-				id: "selectAllBtn",
-				title: "Select All",
-				class: "tool-button",
-				onclick: "EditingTools.selectAll()",
-				iconName: "select_all",
-			})
-		);
-		holderDiv.appendChild(
-         createButtonWithIcon({
-				id: "deleteBtn",
-				title: "Delete",
-				class: "tool-button",
-				onclick: "EditingTools.delete()",
-				iconName: "trash",
-			})
-		);
+		for (let tool of EditingTools.tools) {
+			if (!tool.showButton) continue;
+
+			const shortcut = tool.shortcut;
+			holderDiv.appendChild(
+				createButtonWithIcon({
+					id: tool.name + "Btn",
+					title: (shortcut ? `${tool.name} (${shortcut.toString()})` : tool.name),
+					class: "tool-button",
+					onclick: tool.func,
+					iconName: tool.icon ?? tool.name.toLowerCase(),
+				})
+			);
+		}
+
+		EditingTools.registerShortcuts();
 	}
 
 	#addHistoryTools(holderDiv) {
-		holderDiv.appendChild(
-         createButtonWithIcon({
-				id: "undoBtn",
-				title: "Undo",
-				class: "tool-button",
-				onclick: "HistoryTools.undo()",
-				iconName: "undo",
-			})
-		);
-		holderDiv.appendChild(
-         createButtonWithIcon({
-				id: "redoBtn",
-				title: "Redo",
-				class: "tool-button",
-				onclick: "HistoryTools.redo()",
-				iconName: "redo",
-			})
-		);
+		for (let tool of HistoryTools.tools) {
+			if (!tool.showButton) continue;
+
+			const shortcut = tool.shortcut;
+			holderDiv.appendChild(
+				createButtonWithIcon({
+					id: tool.name + "Btn",
+					title: (shortcut ? `${tool.name} (${shortcut.toString()})` : tool.name),
+					class: "tool-button",
+					onclick: tool.func,
+					iconName: tool.icon ?? tool.name.toLowerCase(),
+				})
+			);
+		}
+
+
+		HistoryTools.registerShortcuts();
 	}
 
 	#addCanvasTools(holderDiv) {
 		for (let tool of CanvasTools.tools) {
 			if (!tool.showButton) continue;
 
+			const shortcut = tool.class.getShortcut();
 			holderDiv.appendChild(
-				createRadioWithImage(tool.name, {
+				createRadioWithImage(tool.name, (shortcut ? `${tool.name} (${shortcut.toString()})` : tool.name), {
 					type: "radio",
 					class: "radio",
 					id: tool.name.toLowerCase() + "Radio",
@@ -116,6 +94,8 @@ class ToolsPanel {
 
 		const selectedTool = CanvasTools.selectTool("Path");
 		this.#selectToolComponent(selectedTool);
+
+		CanvasTools.registerShortcuts();
 	}
 
 	#selectToolComponent(tool) {

--- a/style.css
+++ b/style.css
@@ -254,6 +254,7 @@ textarea {
 	width: 100%;
 	overflow: hidden;
 	white-space: nowrap;
+	--animation-play-state: paused;
 }
 
 #contributors {
@@ -264,13 +265,18 @@ textarea {
 	padding-top: 3px;
 	padding-bottom: 3px;
 	display: inline-block;
-	animation: scroll-left 180s linear normal;
-	width: 100%;
+	animation: scroll-left 60s linear normal infinite;
+	animation-delay: -30s;
+	animation-play-state: var(--animation-play-state);
+}
+
+#contributorsContainer:hover {
+	--animation-play-state: running;
 }
 
 @keyframes scroll-left {
 	0% {
-		transform: translateX(10%);
+		transform: translateX(100%);
 	}
 	100% {
 		transform: translateX(-100%);

--- a/test.html
+++ b/test.html
@@ -34,6 +34,7 @@
       
 		<script src="utils/vector.js"></script>
 		<script src="utils/boundingBox.js"></script>
+		<script src="utils/shortcuts.js"></script>
 
 		<script src="display/layer.js"></script>
 		<script src="display/viewport.js"></script>
@@ -49,6 +50,7 @@
 		<script src="shapes/path.js"></script>
 		<script src="shapes/line.js"></script>
 		<script src="shapes/myImage.js"></script>
+		<script src="tools/genericTool.js"></script>
 		<script src="tools/selectTool.js"></script>
 		<script src="tools/shapes/shapeTool.js"></script>
 		<script src="tools/shapes/pathGeneratedShapeTool.js"></script>
@@ -73,7 +75,6 @@
 		<script src="contributors.js"></script>
 		<script src="utils/misc.js"></script>
 		<script src="main.js"></script>
-		<script src="utils/shortcuts.js"></script>
 		<script src="transformBox/gizmo.js"></script>
 		<script src="transformBox/handle.js"></script>
       

--- a/tools/canvasTools.js
+++ b/tools/canvasTools.js
@@ -5,9 +5,18 @@ class CanvasTools {
 		{ name: "Rect", class: new RectTool(), showButton: true },
 		{ name: "Oval", class: new OvalTool(), showButton: true },
 		{ name: "Text", class: new TextTool(), showButton: true },
-		{ name: "Select", class: SelectTool, showButton: true },
+		{ name: "Select", class: new SelectTool(), showButton: true },
 		{ name: "Image", class: new MyImageTool(), showButton: false },
 	];
+
+	static registerShortcuts() {
+		CanvasTools.tools.forEach((tool) => {
+			const shortcut = tool.class.getShortcut();
+			if (shortcut) {
+				shortcutManager.addShortcut(shortcut);
+			}
+		});
+	}
 
 	static selectTool(type) {
 		CanvasTools.tools.forEach((tool) => tool.class.removeEventListeners());
@@ -19,4 +28,6 @@ class CanvasTools {
 
 		return tool;
 	}
+
+	
 }

--- a/tools/documentTools.js
+++ b/tools/documentTools.js
@@ -1,4 +1,49 @@
 class DocumentTools {
+	static tools = [
+		{
+			name: "Save",
+			func: "DocumentTools.save()",
+			showButton: true,
+			icon: "save",
+			shortcut: new Shortcut({
+				control: true,
+				key: "s",
+				action: DocumentTools.save,
+			}),
+		},
+		{
+			name: "Export",
+			func: "DocumentTools.do_export()",
+			showButton: true,
+			icon: "export",
+			shortcut: new Shortcut({
+				control: true,
+				key: "x",
+				action: DocumentTools.do_export,
+			}),
+		},
+		{
+			name: "Load",
+			func: "DocumentTools.load()",
+			icon: "load",
+			showButton: true,
+			shortcut: new Shortcut({
+				control: true,
+				key: "l",
+				action: DocumentTools.load,
+			}),
+		},
+	];
+
+	static registerShortcuts() {
+		DocumentTools.tools.forEach((tool) => {
+			const shortcut = tool.shortcut;
+			if (shortcut) {
+				shortcutManager.addShortcut(shortcut);
+			}
+		});
+	}
+	
 	static save() {
 		const data = JSON.stringify(viewport.layers.map((l) => l.serialize()));
 
@@ -22,7 +67,7 @@ class DocumentTools {
 				if (extension === "json") {
 					const data = JSON.parse(e.target.result);
 					viewport.setLayers(data);
-               // To-Do reorganize the save file (stageProperties only once)
+					// To-Do reorganize the save file (stageProperties only once)
 					resizeStage(
 						data[0].stageProperties.width,
 						data[0].stageProperties.height
@@ -58,26 +103,26 @@ class DocumentTools {
 
 	static do_export() {
 		const tmpCanvas = document.createElement("canvas");
-      const stageProperties = viewport.layers[0].stageProperties;
+		const stageProperties = viewport.layers[0].stageProperties;
 		tmpCanvas.width = stageProperties.width;
 		tmpCanvas.height = stageProperties.height;
 		const tmpCtx = tmpCanvas.getContext("2d");
 
-      tmpCtx.translate(-stageProperties.left, -stageProperties.top);
+		tmpCtx.translate(-stageProperties.left, -stageProperties.top);
 
-      const allShapes = [];
-      for (const layer of viewport.layers) {
-         if (layer.type == Layer.TYPES.NORMAL) {
-            allShapes.push(...layer.shapes);
-         }
-      }
-         
-      for (const item of allShapes) {
-         rotateCanvas(tmpCtx, item.center, item.rotation);
-         item.draw(tmpCtx);
-         rotateCanvas(tmpCtx, item.center, -item.rotation);
-      }
-   
+		const allShapes = [];
+		for (const layer of viewport.layers) {
+			if (layer.type == Layer.TYPES.NORMAL) {
+				allShapes.push(...layer.shapes);
+			}
+		}
+
+		for (const item of allShapes) {
+			rotateCanvas(tmpCtx, item.center, item.rotation);
+			item.draw(tmpCtx);
+			rotateCanvas(tmpCtx, item.center, -item.rotation);
+		}
+
 		tmpCanvas.toBlob((blob) => {
 			const a = document.createElement("a");
 			a.href = URL.createObjectURL(blob);

--- a/tools/editingTools.js
+++ b/tools/editingTools.js
@@ -1,5 +1,69 @@
 class EditingTools {
 	static clipboard = null;
+	static tools = [
+		{
+			name: "Duplicate",
+			func: "EditingTools.duplicate()",
+			showButton: true,
+			icon: "copy",
+			shortcut: new Shortcut({
+				control: true,
+				key: "d",
+				action: EditingTools.duplicate,
+			}),
+		},
+		{
+			name: "Select All",
+			func: "EditingTools.selectAll()",
+			showButton: true,
+			icon: "select_all",
+			shortcut: new Shortcut({
+				control: true,
+				key: "a",
+				action: EditingTools.selectAll,
+			}),
+		},
+		{
+			name: "Delete",
+			func: "EditingTools.delete()",
+			showButton: true,
+			icon: "trash",
+			shortcut: new Shortcut({
+				control: false,
+				key: "Delete",
+				action: EditingTools.delete,
+			}),
+		},
+		{
+			name: "Copy",
+			func: "EditingTools.copy()",
+			showButton: false,
+			shortcut: new Shortcut({
+				control: true,
+				key: "c",
+				action: EditingTools.copy,
+			}),
+		},
+		{
+			name: "Paste",
+			func: "EditingTools.paste()",
+			showButton: false,
+			shortcut: new Shortcut({
+				control: true,
+				key: "v",
+				action: EditingTools.paste,
+			}),
+		},
+	];
+
+	static registerShortcuts() {
+		EditingTools.tools.forEach((tool) => {
+			const shortcut = tool.shortcut;
+			if (shortcut) {
+				shortcutManager.addShortcut(shortcut);
+			}
+		});
+	}
 
 	static selectAll() {
 		viewport.selectShapes(viewport.selectedLayer.shapes)

--- a/tools/genericTool.js
+++ b/tools/genericTool.js
@@ -1,0 +1,10 @@
+//Should only be used as an abstract class
+class GenericTool {
+    constructor() {
+
+    }
+
+    getShortcut() {
+		return null;
+	}
+}

--- a/tools/historyTools.js
+++ b/tools/historyTools.js
@@ -2,6 +2,40 @@ class HistoryTools {
 	static redoStack = [];
 	static undoStack = [];
 
+	static tools = [
+		{
+			name: "Undo",
+			func: "HistoryTools.undo()",
+			showButton: true,
+			icon: "undo",
+			shortcut: new Shortcut({
+				control: true,
+				key: "z",
+				action: HistoryTools.undo,
+			}),
+		},
+		{
+			name: "Redo",
+			func: "HistoryTools.redo()",
+			showButton: true,
+			icon: "redo",
+			shortcut: new Shortcut({
+				control: true,
+				key: "y",
+				action: HistoryTools.redo,
+			}),
+		},
+	];
+
+	static registerShortcuts() {
+		HistoryTools.tools.forEach((tool) => {
+			const shortcut = tool.shortcut;
+			if (shortcut) {
+				shortcutManager.addShortcut(shortcut);
+			}
+		});
+	}
+
 	static redo() {
 		if (HistoryTools.redoStack.length > 0) {
 			const data = HistoryTools.redoStack.pop();

--- a/tools/selectTool.js
+++ b/tools/selectTool.js
@@ -1,5 +1,13 @@
-class SelectTool {
-	static addPointerDownListener(e) {
+class SelectTool extends GenericTool {
+	constructor() {
+		super();
+	}
+
+	getShortcut() {
+		return new Shortcut({ control: false, key: "v", action: () => CanvasTools.selectTool("Select") });
+	}
+
+	addPointerDownListener(e) {
 		if (e.button !== 0) return;
 
 		const startPosition = new Vector(e.offsetX, e.offsetY);
@@ -78,11 +86,11 @@ class SelectTool {
 				.addEventListener("pointermove", moveCallback);
 			viewport.getStageCanvas().addEventListener("pointerup", upCallback);
 		} else {
-			SelectTool.selectShapesUnderRectangle(e);
+			this.selectShapesUnderRectangle(e);
 		}
 	}
 
-	static selectShapesUnderRectangle(e) {
+	selectShapesUnderRectangle(e) {
 		const startPosition = viewport.getAdjustedPosition(
 			Vector.fromOffsets(e)
 		)
@@ -152,15 +160,15 @@ class SelectTool {
 		viewport.getStageCanvas().addEventListener("pointerup", upCallback);
 	}
 
-	static configureEventListeners() {
+	configureEventListeners() {
 		viewport
 			.getStageCanvas()
-			.addEventListener("pointerdown", this.addPointerDownListener);
+			.addEventListener("pointerdown", this.addPointerDownListener.bind(this));
 	}
 
-	static removeEventListeners() {
+	removeEventListeners() {
 		viewport
 			.getStageCanvas()
-			.removeEventListener("pointerdown", this.addPointerDownListener);
+			.removeEventListener("pointerdown", this.addPointerDownListener.bind(this));
 	}
 }

--- a/tools/shapes/lineTool.js
+++ b/tools/shapes/lineTool.js
@@ -3,4 +3,8 @@ class LineTool extends PathGeneratedShapeTool {
 		super();
 		this._shape = Line
 	}
+
+	getShortcut() {
+		return new Shortcut({ control: false, key: "l", action: () => CanvasTools.selectTool("Line") })
+	}
 }

--- a/tools/shapes/ovalTool.js
+++ b/tools/shapes/ovalTool.js
@@ -3,6 +3,10 @@ class OvalTool extends CornerGeneratedShapeTool {
 		super();
 	}
 
+	getShortcut() {
+		return new Shortcut({ control: false, key: "o", action: () => CanvasTools.selectTool("Oval") });
+	}
+
 	addPointerDownListener(e) {
 		if (e.button !== 0) return;
 

--- a/tools/shapes/pathTool.js
+++ b/tools/shapes/pathTool.js
@@ -3,4 +3,8 @@ class PathTool extends PathGeneratedShapeTool {
 		super();
 		this._shape = Path
 	}
+
+	getShortcut() {
+		return new Shortcut({ control: false, key: "p", action: () => CanvasTools.selectTool("Path") });
+	}
 }

--- a/tools/shapes/rectTool.js
+++ b/tools/shapes/rectTool.js
@@ -3,6 +3,10 @@ class RectTool extends CornerGeneratedShapeTool {
 		super();
 	}
 
+	getShortcut() {
+		return new Shortcut({ control: false, key: "r", action: () => CanvasTools.selectTool("Rect") });
+	}
+
 	addPointerDownListener(e) {
 		if (e.button !== 0) return;
 

--- a/tools/shapes/shapeTool.js
+++ b/tools/shapes/shapeTool.js
@@ -1,5 +1,6 @@
-class ShapeTool {
+class ShapeTool extends GenericTool {
 	constructor() {
+		super();
 		this.boundEventListener = null;
 	}
 

--- a/tools/shapes/textTool.js
+++ b/tools/shapes/textTool.js
@@ -3,6 +3,10 @@ class TextTool extends ShapeTool {
 		super();
 	}
 
+	getShortcut() {
+		return new Shortcut({ control: false, key: "t", action: () => CanvasTools.selectTool("Text") });
+	}
+
 	addPointerDownListener(e) {
 		if (e.button !== 0) return;
 

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -53,15 +53,16 @@ function createButtonWithIcon(attributes) {
 	return button;
 }
 
-function createRadioWithImage(labelText, attributes) {
+function createRadioWithImage(iconName, labelText, attributes) {
 	const element = document.createElement("div");
 	const label = createDOMElement("label", {
-		for: attributes["id"] || labelText.toLowerCase(),
+		for: attributes["id"] || iconName.toLowerCase(),
 		class: "radio-button-button",
 	});
 	const image = new Image();
-	image.src = `drawings/icons/${labelText.toLowerCase()}.png`;
+	image.src = `drawings/icons/${iconName.toLowerCase()}.png`;
 	image.classList.add("icon");
+	image.title = labelText;
 	label.appendChild(image);
 
 	element.appendChild(label);


### PR DESCRIPTION
Shortcuts & Tools Panel
* Shortcuts attached directly to the tools
* Support for mac (Meta key instead of CTRL)
* Show the shortcut keys in the UI
* Made the toolsPanel more dynamic, move the tools configs to its own classes

Some small UX stuff:
* Make sure you can scroll the layer panel when there are a lot of layers
* Contributors list is static, will scroll on hover