### PR TITLE
fix: clear SelectTool events on tool change

### DIFF
--- a/tools/selectTool.js
+++ b/tools/selectTool.js
@@ -86,11 +86,11 @@ class SelectTool extends GenericTool {
 				.addEventListener("pointermove", moveCallback);
 			viewport.getStageCanvas().addEventListener("pointerup", upCallback);
 		} else {
-			this.selectShapesUnderRectangle(e);
+			SelectTool.selectShapesUnderRectangle(e);
 		}
 	}
 
-	selectShapesUnderRectangle(e) {
+	static selectShapesUnderRectangle(e) {
 		const startPosition = viewport.getAdjustedPosition(
 			Vector.fromOffsets(e)
 		)
@@ -163,12 +163,12 @@ class SelectTool extends GenericTool {
 	configureEventListeners() {
 		viewport
 			.getStageCanvas()
-			.addEventListener("pointerdown", this.addPointerDownListener.bind(this));
+			.addEventListener("pointerdown", this.addPointerDownListener);
 	}
 
 	removeEventListeners() {
 		viewport
 			.getStageCanvas()
-			.removeEventListener("pointerdown", this.addPointerDownListener.bind(this));
+			.removeEventListener("pointerdown", this.addPointerDownListener);
 	}
 }


### PR DESCRIPTION
Calling  `.bind` on a listener while registering / unregistering a listener returns a copy of that listener not the listener itself. This caused a leak where the listener is never cleaned up. 