### PR TITLE
Cache chroma/filter to improve filtered image redraw performance

### DIFF
--- a/filters/chroma.js
+++ b/filters/chroma.js
@@ -17,10 +17,14 @@ class Chroma {
       };
    }
 
-	apply(img) {
+   apply(img) {
 		if (this.cache) {
-			// Disabling it for now
-			// return this.cache;
+			if (
+				this.cache.prevColorKey == this.colorKey
+				&& this.cache.prevThreshold == this.threshold
+			) {
+				return this.cache.canvas
+			}
 		}
 		const canvas = document.createElement("canvas");
 		canvas.width = img.width;
@@ -43,9 +47,10 @@ class Chroma {
 			}
 		}
 		ctx.putImageData(imgData, 0, 0);
-		this.cache = canvas;
+		this.cache = {canvas, prevColorKey: this.colorKey, prevThreshold: this.threshold};
 		return canvas;
 	}
+
 	getHexColor() {
 		return `#${this.colorKey[0]
 			.toString(16)

--- a/filters/chroma.js
+++ b/filters/chroma.js
@@ -26,6 +26,7 @@ class Chroma {
 				return this.cache.canvas
 			}
 		}
+
 		const canvas = document.createElement("canvas");
 		canvas.width = img.width;
 		canvas.height = img.height;

--- a/shapes/myImage.js
+++ b/shapes/myImage.js
@@ -68,6 +68,15 @@ class MyImage extends Shape {
 	}
 
 	draw(ctx, hitRegion = false) {
+		if (!this.img.complete) {
+			// prevent errors in drawing image when it is not
+			// fully loaded.
+			setTimeout(() => {
+				this.draw(ctx, hitRegion)
+			}, 50)
+			return
+		}
+
 		const center = this.center ? this.center : { x: 0, y: 0 };
 		let left, top, width, height;
 


### PR DESCRIPTION
- Cache filtered images whose filter properties are not changed between redraw
- Delay drawing of loaded images if image not completely loaded by browser. Initially, loading an image might throw errors during draw since `MyImage.load` does not wait for the `onload` event before returning the image.