### PR TITLE
Fix: device pixel ratio

### DIFF
--- a/tools/selectTool.js
+++ b/tools/selectTool.js
@@ -10,7 +10,7 @@ class SelectTool extends GenericTool {
 	addPointerDownListener(e) {
 		if (e.button !== 0) return;
 
-		const startPosition = new Vector(e.offsetX, e.offsetY);
+		const startPosition = new Vector(e.offsetX, e.offsetY).scale(window.devicePixelRatio);
 
 		const [r, g, b, a] = viewport.hitTestLayer.ctx.getImageData(
 			startPosition.x,
@@ -51,8 +51,8 @@ class SelectTool extends GenericTool {
 			let isDragging = false;
 
 			const moveCallback = function (e) {
-				const mousePosition = new Vector(e.offsetX, e.offsetY);
-				const diff = Vector.subtract(mousePosition, startPosition);
+				const mousePosition = new Vector(e.offsetX, e.offsetY).scale(window.devicePixelRatio);
+				const diff = Vector.subtract(mousePosition, startPosition).scale(1/window.devicePixelRatio);
 				mouseDelta = viewport.getAdjustedScale(diff);
 				isDragging = true;
 				selectedShapes.forEach((s, i) => {

--- a/transformBox/gizmo.js
+++ b/transformBox/gizmo.js
@@ -84,8 +84,8 @@ class Gizmo {
 		let mouseDelta = null;
 		const prevSize = { width: this.box.width, height: this.box.height };
 		const moveCallback = (e) => {
-			const mousePosition = new Vector(e.offsetX, e.offsetY);
-			const diff = Vector.subtract(mousePosition, startPosition);
+			const mousePosition = new Vector(e.offsetX, e.offsetY).scale(window.devicePixelRatio);
+			const diff = Vector.subtract(mousePosition, startPosition).scale(1/window.devicePixelRatio);
 			const polar = diff.toPolar();
 			polar.dir -= this.rotation;
 			diff.toXY(polar);
@@ -151,8 +151,8 @@ class Gizmo {
 				const oldRotation = oldRotations[i];
 
 				if (handle.type === Handle.TYPES.ROTATE) {
-					const fixedStart = viewport.getAdjustedPosition(startPosition);
-					const fixedMouse = viewport.getAdjustedPosition(mousePosition);
+					const fixedStart = viewport.getAdjustedPosition(startPosition.scale(1/window.devicePixelRatio));
+					const fixedMouse = viewport.getAdjustedPosition(mousePosition.scale(1/window.devicePixelRatio));
 
 					// vectors centered at the bounding box center
 					const v1 = Vector.subtract(fixedStart, oldBox.center);

--- a/transformBox/gizmo.js
+++ b/transformBox/gizmo.js
@@ -47,8 +47,10 @@ class Gizmo {
 			new Handle(Vector.mid([bottomLeft, bottomRight]), Handle.TYPES.BOTTOM),
 			new Handle(Vector.mid([topLeft, bottomLeft]), Handle.TYPES.LEFT),
 			new Handle(Vector.mid([topRight, bottomRight]), Handle.TYPES.RIGHT),
-			new Handle(rotationPoint, Handle.TYPES.ROTATE),
 		];
+		this.handles.push(
+			new Handle(rotationPoint, Handle.TYPES.ROTATE, this.handles[4])
+		);
 	}
 
 	#update() {

--- a/transformBox/handle.js
+++ b/transformBox/handle.js
@@ -12,10 +12,11 @@ class Handle {
 		ROTATE: "rotate",
 	};
 
-	constructor(center, type) {
+	constructor(center, type, attachedHandle = null) {
 		this.center = center;
 		this.id = Shape.generateId();
 		this.type = type;
+		this.attachedHandle = attachedHandle;
 	}
 
 	draw(ctx, hitRegion = false) {
@@ -37,6 +38,15 @@ class Handle {
 				size,
 				size
 			);
+			if (this.attachedHandle) {
+				ctx.moveTo(this.center.x, this.center.y);
+				ctx.lineTo(
+					this.attachedHandle.center.x,
+					this.attachedHandle.center.y
+				);
+				ctx.strokeStyle = "black";
+				ctx.stroke();
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Selection / resizing / rotating was broken on retina screens due to using the pixelRatio scaling on the canvas context
- Small update on rotate handle to "attach" it to top handle