### PR TITLE
make filters input usable oninput

### DIFF
--- a/panels/sections/filtersSection.js
+++ b/panels/sections/filtersSection.js
@@ -34,6 +34,12 @@ class FiltersSection extends PanelSection {
 				createDOMElement("input", {
 					id: "colorKey_" + i,
 					onchange: (e) => this.changeChromaKey(i, e.currentTarget.value),
+					oninput: (e) => {
+						const valueCopy = e.currentTarget.value
+						const operation = () => this.changeChromaKey(i, valueCopy)
+						const key = "colorKey_" + i
+						TimeSharer.run(key, operation)
+					},
 					title: "Color Key",
 					value: filter.getHexColor(),
 					type: "color",
@@ -46,6 +52,12 @@ class FiltersSection extends PanelSection {
 					min: "0",
 					onchange: (e) =>
 						this.changeChromaThreshold(i, e.currentTarget.value),
+					oninput: (e) => {
+						const valueCopy = e.currentTarget.value
+						const operation = () => this.changeChromaThreshold(i, valueCopy)
+						const key = "threshold_" + i
+						TimeSharer.run(key, operation)
+					},
 					title: "Threshold",
 					type: "range",
 					value: filter.threshold,

--- a/utils/misc.js
+++ b/utils/misc.js
@@ -121,16 +121,13 @@ class TimeSharer {
 			let opRecord = TimeSharer.opRecords[key]
 			if (Date.now() - opRecord.opTime < opRecord.opInterval) {
 				const latestOpTime = opRecord.opTime
-				// opRecord.latestOp = null is important so as to not
-				// run out dated op in previously set setTimeot below
-				opRecord.latestOp = null
 				opRecord.latestOp = operation
 				setTimeout(
 					() => {
 						if (opRecord.opTime === latestOpTime && opRecord.latestOp) {
 							// no operations since so run the last skipped op
 							opRecord.latestOp()
-							opRecord.latestOp = null
+							opRecord.latestOp = null // dedup executing last op
 						}
 					},
 					opRecord.opInterval


### PR DESCRIPTION
- This update allows Filter/chroma inputs to register `oninput` events
- previously it was too slow, so it was left out altogether
- Now we can get feedback on how filters look whilst changing the filter color or its treshold
- Not 100% smooth but I think it is usable and the near-instant feedback improves the UX.